### PR TITLE
Fix nullpointer exception for non set tvs

### DIFF
--- a/assets/components/imageplus/mgr/js/imageplus.migx_renderer.js
+++ b/assets/components/imageplus/mgr/js/imageplus.migx_renderer.js
@@ -22,6 +22,7 @@
  */
 
 ImagePlus.MIGX_Renderer = function (json) {
+    if (json == null || json == undefined ) return '';
     if (!json.length) return '';
     var data = JSON.parse(json);
     var url = ImagePlus.generateThumbUrl({


### PR DESCRIPTION
It may happen that the tv has not been set. The json parameter is null then, and the .length-check causes an exception resulting in the whole grid not being displayed. I discovered this when I used the Renderer for Collections, not MIGX.
